### PR TITLE
Merge Vertical Offset option from mohebifar/react-native-copilot

### DIFF
--- a/src/hocs/copilot.js
+++ b/src/hocs/copilot.js
@@ -37,6 +37,7 @@ const copilot = ({
   animated,
   androidStatusBarVisible,
   backdropColor,
+  verticalOffset = 0,
 } = {}) =>
   (WrappedComponent) => {
     class Copilot extends Component<any, State> {
@@ -178,7 +179,7 @@ const copilot = ({
           width: size.width + OFFSET_WIDTH,
           height: size.height + OFFSET_WIDTH,
           left: size.x - (OFFSET_WIDTH / 2),
-          top: size.y - (OFFSET_WIDTH / 2),
+          top: size.y - (OFFSET_WIDTH / 2) + verticalOffset,
         });
       }
 


### PR DESCRIPTION
We are using your branch while we wait the main project to merge your changes for the scrollview, thus we would need to have the verticalOffset option available in last versions, in order to properly position copilot steps in Android and iOS.